### PR TITLE
added Meetup link to index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,6 +15,8 @@ main entrance to the building is locked after 6:30&nbsp;PM.**
 
 <p id="doorbell-message"></p>
 
+Let us know that you're coming on [Meetup](https://www.meetup.com/en-AU/SC-Codes-Greenville-Community/)!
+
 ## Hack Nights
 
 Evenings devoted to working on FCC projects and challenges. Campers use this


### PR DESCRIPTION
The main page did not have a link to the weekly Meetup.com information, so I added it. I think the repo has all the info for deploying the site to S3, but I'm not exactly comfortable trying that out yet. Maybe I will try that on Thursday at the meetup.

Happy Halloween!